### PR TITLE
race condition IntegrityError fix

### DIFF
--- a/rlmolecule/alphazero/alphazero_problem.py
+++ b/rlmolecule/alphazero/alphazero_problem.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import random
 from abc import abstractmethod
@@ -13,6 +14,8 @@ from rlmolecule.sql.query import get_existing_reward
 from rlmolecule.sql.tables import GameStore, RewardStore
 from rlmolecule.tree_search.graph_search_state import GraphSearchState
 from rlmolecule.tree_search.reward import Reward
+
+logger = logging.getLogger(__name__)
 
 
 class AlphaZeroProblem(MCTSProblem):
@@ -71,6 +74,7 @@ class AlphaZeroProblem(MCTSProblem):
                 self.session.merge(record)
                 self.session.commit()
             except exc.IntegrityError:
+                logger.debug(f"Duplicate reward entry encountered with {state}")
                 self.session.rollback()
 
         return self.reward_class(reward)

--- a/rlmolecule/alphazero/alphazero_problem.py
+++ b/rlmolecule/alphazero/alphazero_problem.py
@@ -9,6 +9,7 @@ from sqlalchemy import exc
 from rlmolecule.alphazero.alphazero_vertex import AlphaZeroVertex
 from rlmolecule.mcts.mcts_problem import MCTSProblem
 from rlmolecule.sql import Base, Session
+from rlmolecule.sql.query import get_existing_reward
 from rlmolecule.sql.tables import GameStore, RewardStore
 from rlmolecule.tree_search.graph_search_state import GraphSearchState
 from rlmolecule.tree_search.reward import Reward
@@ -52,7 +53,7 @@ class AlphaZeroProblem(MCTSProblem):
         :param state: The state for which rewards are cached
         :return: the scaled reward
         """
-        existing_record = self.session.query(RewardStore).get((hash(state), self.run_id, state.serialize()))
+        existing_record = get_existing_reward(self.session, self.run_id, state)
         if existing_record is not None:
             reward = existing_record.reward
 

--- a/rlmolecule/sql/query.py
+++ b/rlmolecule/sql/query.py
@@ -1,0 +1,28 @@
+import logging
+
+import sqlalchemy
+
+from rlmolecule.sql.tables import RewardStore
+from rlmolecule.tree_search.graph_search_state import GraphSearchState
+
+logger = logging.getLogger(__name__)
+
+
+def get_existing_reward(session: sqlalchemy.orm.session.Session,
+                        run_id: str,
+                        state: GraphSearchState):
+
+    query = session.query(RewardStore).filter(RewardStore.hash == hash(state)).filter(RewardStore.run_id == run_id)
+    num_results = query.count()
+    if num_results == 0:
+        return None
+
+    elif num_results == 1:
+        return query.one()
+
+    # This must be a hash collision
+    else:
+        logger.debug(f"Hash collision observed for state {state} with hash {hash(state)}")
+        return query.filter(RewardStore.state == state.serialize()).one()
+
+

--- a/rlmolecule/sql/tables.py
+++ b/rlmolecule/sql/tables.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, DateTime, Float, Integer, BigInteger, JSON, String, func
+from sqlalchemy import BigInteger, Column, DateTime, Float, Index, Integer, JSON, String, UniqueConstraint, func
 
 from rlmolecule.sql import Base
 
@@ -6,12 +6,16 @@ from rlmolecule.sql import Base
 class RewardStore(Base):
     __tablename__ = 'Reward'
 
-    hash = Column(BigInteger, primary_key=True)
-    run_id = Column(String, primary_key=True)
-    state = Column(String, primary_key=True)
+    index = Column(Integer, primary_key=True)
+    hash = Column(BigInteger)
+    run_id = Column(String)
+    state = Column(String)
     time = Column(DateTime, server_default=func.now())
     reward = Column(Float)
     data = Column(JSON)
+    __table_args__ = (UniqueConstraint('state', 'run_id', name='_state_runid_uc'),
+                      Index('hash', 'run_id'),
+                      )
 
 
 class GameStore(Base):


### PR DESCRIPTION
Currently only handles Dave's error
```
sqlalchemy.exc.IntegrityError: (sqlite3.IntegrityError) UNIQUE constraint failed: Reward.hash, Reward.run_id, Reward.state
[SQL: INSERT INTO "Reward" (hash, run_id, state, reward, data) VALUES (?, ?, ?, ?, ?)]
[parameters: (-6204249827347504057, 'hallway_example', 'gANjZ3ltX3N0YXRlCkd5bUVudlN0YXRlCnEAKYFxAX1xAihYBAAAAF9lbnZxA2NfX21haW5fXwpIYWxsd2F5QWxwaGFaZXJvRW52CnEEKYFxBX1xBihYAwAAAGVudnEHY2hhbGx3YXlfZW52Ckhhb ... (1030 characters truncated) ... tZXRhZGF0YXFMfXFNWAwAAAByZW5kZXIubW9kZXNxTl1xT3N1YlgMAAAAX3N0ZXBfcmV3YXJkcVBK8P///1gSAAAAX2N1bXVsYXRpdmVfcmV3YXJkcVFHwHAAAAAAAABYBQAAAF9kb25lcVKIdWIu', -256.0, '{}')]
(Background on this error at: http://sqlalche.me/e/13/gkpj)
```
Would be slightly more changes to factor out the serialized node from the primary key