### PR TITLE
Check for cycles on adding new edges

### DIFF
--- a/rlmolecule/mcts/mcts.py
+++ b/rlmolecule/mcts/mcts.py
@@ -122,6 +122,8 @@ class MCTS(GraphSearch[MCTSVertex]):
             leaf.children = [self.get_vertex_for_state(state) for state in leaf.state.get_next_actions()]
 
             for child in leaf.children:
+                # child.children is initialized to None, so this only checks nodes where a transposition pointed
+                # to an already existing node in the MCTS graph.
                 if child.children is not None:
                     dfs(set(), child, leaf)
 

--- a/rlmolecule/mcts/mcts.py
+++ b/rlmolecule/mcts/mcts.py
@@ -5,6 +5,7 @@ from typing import Callable, List, Optional, Type
 
 import numpy as np
 
+from rlmolecule.tree_search.dfs import dfs
 from rlmolecule.tree_search.reward import Reward
 from rlmolecule.mcts.mcts_problem import MCTSProblem
 from rlmolecule.mcts.mcts_vertex import MCTSVertex
@@ -113,11 +114,16 @@ class MCTS(GraphSearch[MCTSVertex]):
         """
         Expansion step of MCTS
         From Wikipedia (https://en.wikipedia.org/wiki/Monte_Carlo_tree_search):
-        Expansion: Unless L ends the game decisively (e.g. win/loss/draw) for either player, create one (or more) child
-        vertices and choose vertex C from one of them. Child vertices are any valid moves from the game position defined by L.
+        Expansion: Unless L ends the game decisively (e.g. win/loss/draw) for either player, create one (or more)
+        child vertices and choose vertex C from one of them. Child vertices are any valid moves from the game
+        position defined by L.
         """
         if leaf.children is None:
             leaf.children = [self.get_vertex_for_state(state) for state in leaf.state.get_next_actions()]
+
+            for child in leaf.children:
+                if child.children is not None:
+                    dfs(set(), child, leaf)
 
     def _evaluate(
             self,

--- a/rlmolecule/tree_search/dfs.py
+++ b/rlmolecule/tree_search/dfs.py
@@ -8,6 +8,8 @@ def dfs(visited: set, node: 'GraphSearchState', parent: 'GraphSearchState') -> N
     :param visited: initialized with an empty set, this builds recursively.
     :param node: The child node from which to search
     :param parent: The parent node which should not be included in child's reachable states.
+
+    :raises GraphCycleError: If the parent node is found in the descendants of node.
     """
     if node not in visited:
 

--- a/rlmolecule/tree_search/dfs.py
+++ b/rlmolecule/tree_search/dfs.py
@@ -1,0 +1,44 @@
+import textwrap
+
+
+def dfs(visited: set, node: 'GraphSearchState', parent: 'GraphSearchState') -> None:
+    """ A depth-first search recursion of the node's children, yielding a GraphCycleError if the parent is found
+    within the descendants of node.
+
+    :param visited: initialized with an empty set, this builds recursively.
+    :param node: The child node from which to search
+    :param parent: The parent node which should not be included in child's reachable states.
+    """
+    if node not in visited:
+
+        visited.add(node)
+
+        if node == parent:
+            raise GraphCycleError(parent)
+
+        if node.children is not None:
+            for child in node.children:
+                dfs(visited, child, parent)
+
+
+class GraphCycleError(Exception):
+    def __init__(self, parent_node):
+        self.parent_node = parent_node
+        super().__init__()
+
+    def __str__(self):
+        return (f'Cyclic edge encountered at state:\n{self.parent_node}.\n' +
+                textwrap.dedent("""
+                This library is currently only equipped to search spaces defined as handle
+                directional acyclic graphs. Cycles inside the search graph give rise to a
+                graph history interaction problem. For more information, see:
+                
+                Childs, B. E., Brodeur, J. H., & Kocsis, L. (2008). Transpositions and move
+                groups in Monte Carlo tree search. 2008 IEEE Symposium On Computational 
+                Intelligence and Games. doi:10.1109/cig.2008.5035667
+                
+                One way to solve this error for search spaces with recurring positions is
+                to add a "time" parameter which tracks the number of moves that have been
+                made. (position, number_of_moves) pairs are therefore unlikely to recur as
+                long as number_of_moves always increases.
+                """))

--- a/rlmolecule/tree_search/dfs.py
+++ b/rlmolecule/tree_search/dfs.py
@@ -1,9 +1,10 @@
 import textwrap
 
 
-def dfs(visited: set, node: 'GraphSearchState', parent: 'GraphSearchState') -> None:
+def dfs(visited: set, node: 'MCTSVertex', parent: 'MCTSVertex') -> None:
     """ A depth-first search recursion of the node's children, yielding a GraphCycleError if the parent is found
-    within the descendants of node.
+    within the descendants of node. This function only searches the cached `children` property of the vertex,
+    so if cycles are present they will only be found after they are added to the MCTS graph.
 
     :param visited: initialized with an empty set, this builds recursively.
     :param node: The child node from which to search
@@ -12,7 +13,6 @@ def dfs(visited: set, node: 'GraphSearchState', parent: 'GraphSearchState') -> N
     :raises GraphCycleError: If the parent node is found in the descendants of node.
     """
     if node not in visited:
-
         visited.add(node)
 
         if node == parent:
@@ -31,9 +31,10 @@ class GraphCycleError(Exception):
     def __str__(self):
         return (f'Cyclic edge encountered at state:\n{self.parent_node}.\n' +
                 textwrap.dedent("""
-                This library is currently only equipped to search spaces defined as handle
+                This library is currently only equipped to search spaces defined as 
                 directional acyclic graphs. Cycles inside the search graph give rise to a
-                graph history interaction problem. For more information, see:
+                graph history interaction problem, which require careful handling. For more
+                information, see:
                 
                 Childs, B. E., Brodeur, J. H., & Kocsis, L. (2008). Transpositions and move
                 groups in Monte Carlo tree search. 2008 IEEE Symposium On Computational 

--- a/tests/tree_search/test_dfs.py
+++ b/tests/tree_search/test_dfs.py
@@ -1,0 +1,69 @@
+from typing import Sequence
+
+import pytest
+
+from rlmolecule.mcts.mcts import MCTS
+from rlmolecule.mcts.mcts_problem import MCTSProblem
+from rlmolecule.tree_search.dfs import GraphCycleError
+from rlmolecule.tree_search.graph_search_state import GraphSearchState
+from rlmolecule.tree_search.reward import LinearBoundedRewardFactory
+
+
+class CyclicState(GraphSearchState):
+    def __init__(self, position, is_terminal):
+        super(CyclicState, self).__init__()
+        self.is_terminal = is_terminal
+        self.position = position
+
+    def equals(self, other: 'CyclicState') -> bool:
+        return (self.position == other.position) & (self.is_terminal == other.is_terminal)
+
+    def __repr__(self):
+        return f"{self.__class__}(position={self.position}, is_terminal={self.is_terminal})"
+
+    def get_next_actions(self) -> Sequence['GraphSearchState']:
+        if self.is_terminal:
+            return []
+
+        else:
+            return [CyclicState(self.position, is_terminal=True),
+                    CyclicState((self.position + 1) % 5, is_terminal=False)]
+
+    def hash(self) -> int:
+        return hash((self.position, self.is_terminal))
+
+
+class AcyclicState(CyclicState):
+    def get_next_actions(self) -> Sequence['GraphSearchState']:
+        if self.is_terminal:
+            return []
+
+        else:
+            return [AcyclicState(self.position, is_terminal=True),
+                    AcyclicState(self.position + 1, is_terminal=False)]
+
+
+class CyclicProblem(MCTSProblem):
+
+    def get_initial_state(self) -> GraphSearchState:
+        return CyclicState(0, is_terminal=False)
+
+    def get_reward(self, state: CyclicState) -> (float, {}):
+        return state.position, {}
+
+
+class AcyclicProblem(CyclicProblem):
+
+    def get_initial_state(self) -> GraphSearchState:
+        return AcyclicState(0, is_terminal=False)
+
+
+def test_dfs():
+
+    game = MCTS(CyclicProblem(reward_class=LinearBoundedRewardFactory(min_reward=0, max_reward=5)))
+    with pytest.raises(GraphCycleError):
+        game.run(num_mcts_samples=100)
+
+    # This shouldn't raise an error
+    game = MCTS(AcyclicProblem(reward_class=LinearBoundedRewardFactory(min_reward=0, max_reward=5)))
+    game.run(num_mcts_samples=100)


### PR DESCRIPTION
This PR adds support for a depth-first search to ensure that self-loops aren't added to the search space.
The tests pass, so I think the functionality is working, but we don't have any profiling set up for this. I'm wondering how much overhead this adds for search spaces where we don't expect any collisions. 