### PR TITLE
Config file containing AZ, MCTS, and database parameters

### DIFF
--- a/examples/qed/config/qed_config_eagle.yaml
+++ b/examples/qed/config/qed_config_eagle.yaml
@@ -32,7 +32,7 @@ train_config:
     min_buffer_size: 15
     batch_size: 32
     # folder in which to store the trained models
-    policy_checkpoint_dir: 'policy_checkpoints'
+    policy_checkpoint_dir: '/projects/rlmolecule/$USER/qed/qed_example/policy_checkpoints'
     # MoleculeTFAlphaZeroProblem options
     num_messages: 1
     num_heads: 2

--- a/examples/qed/config/qed_config_eagle.yaml
+++ b/examples/qed/config/qed_config_eagle.yaml
@@ -1,0 +1,49 @@
+# Optimize the Quantitative Estimate of Drug-likeness (QED)
+# See https://www.rdkit.org/docs/source/rdkit.Chem.QED.html
+# Starting point: a single carbon (C)
+#   - actions: add a bond or an atom
+#   - state: molecule state
+#   - reward: 0, unless a terminal state is reached, then the qed estimate of the molecule
+
+run_config:
+    run_id: 'qed_example'
+
+# Parameters for setting up the problem
+problem_config:
+    max_atoms: 200
+    min_atoms: 1
+    policy_checkpoint_dir: 'policy_checkpoints'
+
+# Parameters for training the policy model
+train_config:
+    ranked_reward_alpha: 0.75
+    reward_buffer_max_size: 50
+    reward_buffer_min_size: 10
+    steps_per_epoch: 100
+    game_count_delay: 20
+    verbose: 2
+    # TODO use these parameters and add the rest
+    #policy_buffer_max_size: 256
+    #policy_buffer_min_size: 128
+
+# Parameters for running the Monte Carlo Tree Search games
+mcts_config:
+    num_mcts_samples: 500
+    min_reward: 0
+    pbc_c_base: 1.0
+    pbc_c_init: 1.25
+    dirichlet_alpha: 1.0
+    dirichlet_x: 0.25
+    #max_depth: 1000000
+
+# Database settings for the Object Relational Model (ORM)
+# Used to store games and communicate between the policy model (run on GPUs) and rollout (run on CPUs)
+sql_database:
+   # settings to connect to NREL's yuma database
+   drivername: "postgresql+psycopg2"
+   dbname: "bde"
+   port: "5432"
+   host: "yuma.hpc.nrel.gov"
+   user: "rlops"
+   # read the password from a file
+   passwd_file: '/projects/rlmolecule/rlops_pass'

--- a/examples/qed/config/qed_config_eagle.yaml
+++ b/examples/qed/config/qed_config_eagle.yaml
@@ -11,6 +11,9 @@ run_id: 'qed_example'
 problem_config:
     max_atoms: 200
     min_atoms: 1
+    try_embedding: True
+    sa_score_threshold: 4
+    stereoisomers: False
 
 # Parameters for training the policy model
 train_config:

--- a/examples/qed/config/qed_config_eagle.yaml
+++ b/examples/qed/config/qed_config_eagle.yaml
@@ -5,36 +5,51 @@
 #   - state: molecule state
 #   - reward: 0, unless a terminal state is reached, then the qed estimate of the molecule
 
-run_config:
-    run_id: 'qed_example'
+run_id: 'qed_example'
 
 # Parameters for setting up the problem
 problem_config:
     max_atoms: 200
     min_atoms: 1
-    policy_checkpoint_dir: 'policy_checkpoints'
 
 # Parameters for training the policy model
 train_config:
+    # reward options:
     ranked_reward_alpha: 0.75
     reward_buffer_max_size: 50
     reward_buffer_min_size: 10
+    # learning options:
+    lr: 1E-3
+    epochs: 1E4
     steps_per_epoch: 100
     game_count_delay: 20
     verbose: 2
-    # TODO use these parameters and add the rest
-    #policy_buffer_max_size: 256
-    #policy_buffer_min_size: 128
+    # AlphaZero problem options
+    max_buffer_size: 200
+    min_buffer_size: 15
+    batch_size: 32
+    # folder in which to store the trained models
+    policy_checkpoint_dir: 'policy_checkpoints'
+    # MoleculeTFAlphaZeroProblem options
+    num_messages: 1
+    num_heads: 2
+    features: 8
 
 # Parameters for running the Monte Carlo Tree Search games
 mcts_config:
-    num_mcts_samples: 500
+    # Minimum reward to return for invalid actions
     min_reward: 0
     pbc_c_base: 1.0
     pbc_c_init: 1.25
+    # dirichlet 'shape' parameter. Larger values spread out probability over more moves.
     dirichlet_alpha: 1.0
+    # percentage to favor dirichlet noise vs. prior estimation. Smaller means less noise
     dirichlet_x: 0.25
-    #max_depth: 1000000
+    # number of samples to perform at each level of the MCTS search
+    num_mcts_samples: 50
+    # the maximum search depth.
+    max_depth: 1000000
+    #ucb_constant: math.sqrt(2)
 
 # Database settings for the Object Relational Model (ORM)
 # Used to store games and communicate between the policy model (run on GPUs) and rollout (run on CPUs)

--- a/examples/qed/config/qed_config_local.yaml
+++ b/examples/qed/config/qed_config_local.yaml
@@ -11,6 +11,9 @@ run_id: 'qed_example_local'
 problem_config:
     max_atoms: 25
     min_atoms: 1
+    try_embedding: True
+    sa_score_threshold: 4
+    stereoisomers: False
 
 # Parameters for training the policy model
 train_config:

--- a/examples/qed/config/qed_config_local.yaml
+++ b/examples/qed/config/qed_config_local.yaml
@@ -1,0 +1,45 @@
+# Optimize the Quantitative Estimate of Drug-likeness (QED)
+# See https://www.rdkit.org/docs/source/rdkit.Chem.QED.html
+# Starting point: a single carbon (C)
+#   - actions: add a bond or an atom
+#   - state: molecule state
+#   - reward: 0, unless a terminal state is reached, then the qed estimate of the molecule
+
+run_config:
+    run_id: 'qed_example_local'
+
+# Parameters for setting up the problem
+problem_config:
+    max_atoms: 25
+    min_atoms: 1
+    policy_checkpoint_dir: 'policy_checkpoints_local'
+
+# Parameters for training the policy model
+alphazero_config:
+    ranked_reward_alpha: 0.75
+    reward_buffer_max_size: 50
+    reward_buffer_min_size: 10
+    steps_per_epoch: 100
+    game_count_delay: 20
+    verbose: 2
+    # TODO use these parameters and add the rest
+    #policy_buffer_max_size: 256
+    #policy_buffer_min_size: 128
+
+# Parameters for running the Monte Carlo Tree Search games
+mcts_config:
+    num_mcts_samples: 50
+    # TODO use this parameter and add the rest
+    pbc_c_base: 1.0
+    pbc_c_init: 1.25
+    dirichlet_alpha: 1.0
+    dirichlet_x: 0.25
+    #max_depth: 1000000
+
+# Database settings for the Object Relational Model (ORM)
+# Used to store games and communicate between the policy model (run on GPUs) and rollout (run on CPUs)
+sql_database:
+   # default database settings:
+   drivername: "sqlite"
+   db_file: "qed_data.db"
+

--- a/examples/qed/config/qed_config_local.yaml
+++ b/examples/qed/config/qed_config_local.yaml
@@ -5,36 +5,51 @@
 #   - state: molecule state
 #   - reward: 0, unless a terminal state is reached, then the qed estimate of the molecule
 
-run_config:
-    run_id: 'qed_example_local'
+run_id: 'qed_example_local'
 
 # Parameters for setting up the problem
 problem_config:
     max_atoms: 25
     min_atoms: 1
-    policy_checkpoint_dir: 'policy_checkpoints_local'
 
 # Parameters for training the policy model
-alphazero_config:
+train_config:
+    # reward options:
     ranked_reward_alpha: 0.75
     reward_buffer_max_size: 50
     reward_buffer_min_size: 10
+    # learning options:
+    lr: 1E-3
+    epochs: 1E4
     steps_per_epoch: 100
     game_count_delay: 20
     verbose: 2
-    # TODO use these parameters and add the rest
-    #policy_buffer_max_size: 256
-    #policy_buffer_min_size: 128
+    # AlphaZero problem options
+    max_buffer_size: 200
+    min_buffer_size: 15
+    batch_size: 32
+    # folder in which to store the trained models
+    policy_checkpoint_dir: 'policy_checkpoints_local'
+    # MoleculeTFAlphaZeroProblem options
+    num_messages: 1
+    num_heads: 2
+    features: 8
 
 # Parameters for running the Monte Carlo Tree Search games
 mcts_config:
-    num_mcts_samples: 50
-    # TODO use this parameter and add the rest
+    # Minimum reward to return for invalid actions
+    min_reward: 0
     pbc_c_base: 1.0
     pbc_c_init: 1.25
+    # dirichlet 'shape' parameter. Larger values spread out probability over more moves.
     dirichlet_alpha: 1.0
+    # percentage to favor dirichlet noise vs. prior estimation. Smaller means less noise
     dirichlet_x: 0.25
-    #max_depth: 1000000
+    # number of samples to perform at each level of the MCTS search
+    num_mcts_samples: 50
+    # the maximum search depth.
+    max_depth: 1000000
+    #ucb_constant: math.sqrt(2)
 
 # Database settings for the Object Relational Model (ORM)
 # Used to store games and communicate between the policy model (run on GPUs) and rollout (run on CPUs)

--- a/examples/qed/optimize_qed.py
+++ b/examples/qed/optimize_qed.py
@@ -78,7 +78,7 @@ def construct_problem(run_config):
         min_buffer_size=train_config.get('min_buffer_size', 15),
         batch_size=train_config.get('batch_size', 32),
         policy_checkpoint_dir=train_config.get(
-            'policy_checkpoints_dir', 'policy_checkpoints')
+            'policy_checkpoint_dir', 'policy_checkpoints')
     )
 
     return problem

--- a/examples/qed/optimize_qed.py
+++ b/examples/qed/optimize_qed.py
@@ -8,17 +8,15 @@ Starting point: a single carbon (C)
 
 import argparse
 import logging
+import math
 import multiprocessing
 import os
 import time
-import math
 
 import rdkit
 from rdkit.Chem.QED import qed
-from sqlalchemy import create_engine
 
-from examples.run_config import Run_Config
-
+from examples.run_config import RunConfig
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -35,13 +33,6 @@ def construct_problem(run_config):
     from rlmolecule.molecule.builder.builder import MoleculeBuilder
 
     class QEDOptimizationProblem(MoleculeTFAlphaZeroProblem):
-
-        def __init__(self,
-                     engine: 'sqlalchemy.engine.Engine',
-                     builder: 'MoleculeBuilder', **kwargs) -> None:
-            super(QEDOptimizationProblem, self).__init__(engine, builder, **kwargs)
-            self._config = builder
-
         def get_initial_state(self) -> MoleculeState:
             return MoleculeState(rdkit.Chem.MolFromSmiles('C'), self._config)
 
@@ -52,11 +43,11 @@ def construct_problem(run_config):
 
     prob_config = run_config.problem_config
     builder = MoleculeBuilder(
-        max_atoms=prob_config.get('max_atoms',25),
-        min_atoms=prob_config.get('min_atoms',1),
-        tryEmbedding=prob_config.get('tryEmbedding',True),
-        sa_score_threshold=prob_config.get('sa_score_threshold',4),
-        stereoisomers=prob_config.get('stereoisomers',False)
+        max_atoms=prob_config.get('max_atoms', 25),
+        min_atoms=prob_config.get('min_atoms', 1),
+        tryEmbedding=prob_config.get('tryEmbedding', True),
+        sa_score_threshold=prob_config.get('sa_score_threshold', 4),
+        stereoisomers=prob_config.get('stereoisomers', False)
     )
 
     engine = run_config.start_engine()
@@ -98,19 +89,19 @@ def run_games(run_config):
     config = run_config.mcts_config
     game = AlphaZero(
         construct_problem(run_config),
-        min_reward=config.get('min_reward',0.0),
-        pb_c_base=config.get('pb_c_base',1.0),
-        pb_c_init=config.get('pb_c_init',1.25),
-        dirichlet_noise=config.get('dirichlet_noise',True),
-        dirichlet_alpha=config.get('dirichlet_alpha',1.0),
-        dirichlet_x=config.get('dirichlet_x',0.25),
+        min_reward=config.get('min_reward', 0.0),
+        pb_c_base=config.get('pb_c_base', 1.0),
+        pb_c_init=config.get('pb_c_init', 1.25),
+        dirichlet_noise=config.get('dirichlet_noise', True),
+        dirichlet_alpha=config.get('dirichlet_alpha', 1.0),
+        dirichlet_x=config.get('dirichlet_x', 0.25),
         # MCTS parameters
-        ucb_constant=config.get('ucb_constant',math.sqrt(2)),
+        ucb_constant=config.get('ucb_constant', math.sqrt(2)),
     )
     while True:
         path, reward = game.run(
-            num_mcts_samples=config.get('num_mcts_samples',50),
-            max_depth=config.get('max_depth',1000000),
+            num_mcts_samples=config.get('num_mcts_samples', 50),
+            max_depth=config.get('max_depth', 1000000),
         )
         logger.info(f'Game Finished -- Reward {reward.raw_reward:.3f} -- Final state {path[-1][0]}')
 
@@ -162,7 +153,7 @@ if __name__ == "__main__":
     parser = setup_argparser()
     args = parser.parse_args()
 
-    run_config = Run_Config(args.config)
+    run_config = RunConfig(args.config)
 
     if args.train_policy:
         train_model(run_config)

--- a/examples/qed/optimize_qed.py
+++ b/examples/qed/optimize_qed.py
@@ -57,7 +57,7 @@ def construct_problem(run_config):
 
     run_id = run_config.run_id
 
-    train_config = run_config.alphazero_config
+    train_config = run_config.train_config
     reward_factory = RankedRewardFactory(
         engine=engine,
         run_id=run_id,

--- a/examples/run_config.py
+++ b/examples/run_config.py
@@ -12,11 +12,13 @@ from sqlalchemy import create_engine
 class Run_Config:
     def __init__(self, config_file, **kwargs):
 
-        with open(config_file, 'r') as f:
-            #self.config_map = yaml.safe_load(f)
-            # expandvars is a neat trick to expand bash variables within the yaml file
-            # from here: https://stackoverflow.com/a/60283894/7483950
-            self.config_map = yaml.safe_load(os.path.expandvars(f.read()))
+        self.config_map = {}
+        if config_file is not None:
+            with open(config_file, 'r') as f:
+                #self.config_map = yaml.safe_load(f)
+                # expandvars is a neat trick to expand bash variables within the yaml file
+                # from here: https://stackoverflow.com/a/60283894/7483950
+                self.config_map = yaml.safe_load(os.path.expandvars(f.read()))
 
         # TODO overwrite settings in the config file if they were passed in via kwargs
         # Settings for setting up scripts to run everything

--- a/examples/run_config.py
+++ b/examples/run_config.py
@@ -1,0 +1,82 @@
+""" Utilities for loading training and game parameters, and for setting up the sql database
+"""
+
+import os
+import yaml
+from sqlalchemy import create_engine
+
+
+# TODO add the command line args that correspond to the config file options here
+
+
+class Run_Config:
+    def __init__(self, config_file, **kwargs):
+
+        with open(config_file, 'r') as f:
+            #self.config_map = yaml.safe_load(f)
+            # expandvars is a neat trick to expand bash variables within the yaml file
+            # from here: https://stackoverflow.com/a/60283894/7483950
+            self.config_map = yaml.safe_load(os.path.expandvars(f.read()))
+
+        # TODO overwrite settings in the config file if they were passed in via kwargs
+        # Settings for setting up scripts to run everything
+        #self.run_config = self.config_map.get('run_config',{})
+        self.run_id = self.config_map.get('run_id','test')
+
+        # Settings specific to the problem at hand
+        self.problem_config = self.config_map.get('problem_config',{})
+        # Settings for training the policy model
+        self.alphazero_config = self.config_map.get('alphazero_config',{})
+        self.mcts_config = self.config_map.get('mcts_config',{})
+
+# def load_config_file(config_file):
+#     with open(config_file, 'r') as conf:
+#         config_map = yaml.load(conf)
+
+#     return config_map
+
+    def start_engine(self):
+        self.engine = Run_Config.start_db_engine(
+            **self.config_map.get('sql_database',{}))
+        return self.engine
+
+    @staticmethod
+    def start_db_engine(**kwargs):
+        """ Connect to the sql database that will store the game and reward data 
+        used by the policy model and game runner
+        """
+        drivername = kwargs.get('drivername', 'sqlite')
+        db_file = kwargs.get('db_file', 'game_data.db')
+        if drivername == 'sqlite':
+            engine = create_engine(
+                f'sqlite:///{db_file}',
+                # The 'check_same_thread' option only works for sqlite
+                connect_args={'check_same_thread': False},
+                execution_options={"isolation_level": "AUTOCOMMIT"})
+        else:
+            engine = Run_Config.start_server_db_engine(**kwargs)
+
+        return engine
+
+    @staticmethod
+    def start_server_db_engine(
+            drivername="postgresql+psycopg2", dbname='bde',
+            port=None, host="yuma.hpc.nrel.gov", user="rlops",
+            passwd_file=None, passwd=None,
+            **kwargs):
+        # add the ':' to separate host from port
+        port = ":"+str(port) if port is not None else ""
+
+        if passwd_file is not None:
+            # read the password from a file
+            with open(passwd_file, 'r') as f:
+                passwd = f.read().strip()
+        # add the ':' to separate user from passwd
+        passwd = ":"+str(passwd) if passwd is not None else ""
+
+        engine_str = f'{drivername}://{user}{passwd}@{host}{port}/{dbname}'
+        # don't print since it has the user's password
+        #print(f'connecting to database using: {engine_str}')
+        engine = create_engine(
+            engine_str, execution_options={"isolation_level": "AUTOCOMMIT"})
+        return engine

--- a/examples/run_config.py
+++ b/examples/run_config.py
@@ -39,7 +39,7 @@ class RunConfig:
     #     return config_map
 
     def start_engine(self):
-        self.engine = Run_Config.start_db_engine(
+        self.engine = RunConfig.start_db_engine(
             **self.config_map.get('sql_database', {}))
         return self.engine
 
@@ -57,7 +57,7 @@ class RunConfig:
                 connect_args={'check_same_thread': False},
                 execution_options={"isolation_level": "AUTOCOMMIT"})
         else:
-            engine = Run_Config.start_server_db_engine(**kwargs)
+            engine = RunConfig.start_server_db_engine(**kwargs)
 
         return engine
 

--- a/examples/run_config.py
+++ b/examples/run_config.py
@@ -29,7 +29,7 @@ class RunConfig:
         # Settings specific to the problem at hand
         self.problem_config = self.config_map.get('problem_config', {})
         # Settings for training the policy model
-        self.alphazero_config = self.config_map.get('alphazero_config', {})
+        self.train_config = self.config_map.get('train_config', {})
         self.mcts_config = self.config_map.get('mcts_config', {})
 
     # def load_config_file(config_file):

--- a/examples/run_config.py
+++ b/examples/run_config.py
@@ -2,6 +2,7 @@
 """
 
 import os
+
 import yaml
 from sqlalchemy import create_engine
 
@@ -9,37 +10,37 @@ from sqlalchemy import create_engine
 # TODO add the command line args that correspond to the config file options here
 
 
-class Run_Config:
+class RunConfig:
     def __init__(self, config_file, **kwargs):
 
         self.config_map = {}
         if config_file is not None:
             with open(config_file, 'r') as f:
-                #self.config_map = yaml.safe_load(f)
+                # self.config_map = yaml.safe_load(f)
                 # expandvars is a neat trick to expand bash variables within the yaml file
                 # from here: https://stackoverflow.com/a/60283894/7483950
                 self.config_map = yaml.safe_load(os.path.expandvars(f.read()))
 
         # TODO overwrite settings in the config file if they were passed in via kwargs
         # Settings for setting up scripts to run everything
-        #self.run_config = self.config_map.get('run_config',{})
-        self.run_id = self.config_map.get('run_id','test')
+        # self.run_config = self.config_map.get('run_config',{})
+        self.run_id = self.config_map.get('run_id', 'test')
 
         # Settings specific to the problem at hand
-        self.problem_config = self.config_map.get('problem_config',{})
+        self.problem_config = self.config_map.get('problem_config', {})
         # Settings for training the policy model
-        self.alphazero_config = self.config_map.get('alphazero_config',{})
-        self.mcts_config = self.config_map.get('mcts_config',{})
+        self.alphazero_config = self.config_map.get('alphazero_config', {})
+        self.mcts_config = self.config_map.get('mcts_config', {})
 
-# def load_config_file(config_file):
-#     with open(config_file, 'r') as conf:
-#         config_map = yaml.load(conf)
+    # def load_config_file(config_file):
+    #     with open(config_file, 'r') as conf:
+    #         config_map = yaml.load(conf)
 
-#     return config_map
+    #     return config_map
 
     def start_engine(self):
         self.engine = Run_Config.start_db_engine(
-            **self.config_map.get('sql_database',{}))
+            **self.config_map.get('sql_database', {}))
         return self.engine
 
     @staticmethod
@@ -67,18 +68,18 @@ class Run_Config:
             passwd_file=None, passwd=None,
             **kwargs):
         # add the ':' to separate host from port
-        port = ":"+str(port) if port is not None else ""
+        port = ":" + str(port) if port is not None else ""
 
         if passwd_file is not None:
             # read the password from a file
             with open(passwd_file, 'r') as f:
                 passwd = f.read().strip()
         # add the ':' to separate user from passwd
-        passwd = ":"+str(passwd) if passwd is not None else ""
+        passwd = ":" + str(passwd) if passwd is not None else ""
 
         engine_str = f'{drivername}://{user}{passwd}@{host}{port}/{dbname}'
         # don't print since it has the user's password
-        #print(f'connecting to database using: {engine_str}')
+        # print(f'connecting to database using: {engine_str}')
         engine = create_engine(
             engine_str, execution_options={"isolation_level": "AUTOCOMMIT"})
         return engine

--- a/rlmolecule/alphazero/alphazero.py
+++ b/rlmolecule/alphazero/alphazero.py
@@ -29,6 +29,7 @@ class AlphaZero(MCTS):
                  dirichlet_noise: bool = True,
                  dirichlet_alpha: float = 1.0,
                  dirichlet_x: float = 0.25,
+                 **kwargs
                  ) -> None:
         """
         Constructor.
@@ -39,7 +40,7 @@ class AlphaZero(MCTS):
         :param dirichlet_alpha: dirichlet 'shape' parameter. Larger values spread out probability over more moves.
         :param dirichlet_x: percentage to favor dirichlet noise vs. prior estimation. Smaller means less noise
         """
-        super().__init__(problem, vertex_class=AlphaZeroVertex)
+        super().__init__(problem, vertex_class=AlphaZeroVertex, **kwargs)
         self._min_reward: float = min_reward
         self._pb_c_base: float = pb_c_base
         self._pb_c_init: float = pb_c_init

--- a/rlmolecule/mcts/mcts.py
+++ b/rlmolecule/mcts/mcts.py
@@ -21,6 +21,7 @@ class MCTS(GraphSearch[MCTSVertex]):
             problem: MCTSProblem,
             ucb_constant: float = math.sqrt(2),
             vertex_class: Optional[Type[MCTSVertex]] = None,
+            **kwargs
     ) -> None:
         super().__init__(MCTSVertex if vertex_class is None else vertex_class)
         self._problem: MCTSProblem = problem


### PR DESCRIPTION
Reviving some of the ideas from #47, without the HPC stuff.

Allowing the user to specify parameters used by the policy training, AlphaZero, MCTS rollouts, and the database in a config file, rather than hard-coded in a script, will enable more experimentation such as a systematic parameter search. For example, a user may want to vary the `dirichlet_x` noise parameter over a range and see how that affects the results. 

Another benefit of having all the parameters in a single file is that there are parameters spread throughout classes and functions in the inheritance hierarchy and they can be hard to find for a new user.

Currently this code uses a config file, but runs using default values if a config file is not given. We could also add a function to `run_config.py` that makes command-line arguments for each of the parameters in the config file. 

Part of the motivation for this is to show the ARPA-E folks the flexibility of the software such as running the QED example on eagle `python optimize_qed.py --config config/qed_config_eagle.yaml` vs running locally `python optimize_qed.py --config config/qed_config_local.yaml`.