### PR TITLE
initial performance metrics implementation

### DIFF
--- a/rlmolecule/mcts/mcts_problem.py
+++ b/rlmolecule/mcts/mcts_problem.py
@@ -1,10 +1,10 @@
 import uuid
 from abc import ABC, abstractmethod
-from typing import Optional
 
 from rlmolecule.mcts.mcts_vertex import MCTSVertex
 from rlmolecule.tree_search.graph_search_state import GraphSearchState
-from rlmolecule.tree_search.reward import RawRewardFactory, Reward, RewardFactory
+from rlmolecule.tree_search.metrics import call_metrics
+from rlmolecule.tree_search.reward import Reward, RewardFactory
 
 
 class MCTSProblem(ABC):
@@ -34,6 +34,7 @@ class MCTSProblem(ABC):
         before conducting the MCTS search every time AlphaZero.run() is called.
         """
         self.__id = uuid.uuid4()
+        call_metrics.reset()
 
     def reward_wrapper(self, vertex: MCTSVertex) -> Reward:
         reward, _ = self.get_reward(vertex.state)

--- a/rlmolecule/molecule/molecule_state.py
+++ b/rlmolecule/molecule/molecule_state.py
@@ -3,6 +3,7 @@ from typing import Optional, Sequence
 from rdkit.Chem import Mol, MolToSmiles
 
 from rlmolecule.tree_search.graph_search_state import GraphSearchState
+from rlmolecule.tree_search.metrics import collect_metrics
 
 
 class MoleculeState(GraphSearchState):
@@ -52,6 +53,7 @@ class MoleculeState(GraphSearchState):
         """
         return hash(self.__repr__()) ^ (13 * self._forced_terminal)
 
+    @collect_metrics
     def get_next_actions(self) -> Sequence['MoleculeState']:
         result = []
         if not self._forced_terminal:

--- a/rlmolecule/sql/tables.py
+++ b/rlmolecule/sql/tables.py
@@ -34,3 +34,4 @@ class GameStore(Base):
     raw_reward = Column(Float)
     scaled_reward = Column(Float)
     search_statistics = Column(JSON)
+    execution_statistics = Column(JSON)

--- a/rlmolecule/tree_search/metrics.py
+++ b/rlmolecule/tree_search/metrics.py
@@ -1,0 +1,38 @@
+from collections import defaultdict, Callable
+from functools import wraps
+from time import time
+
+
+class CallMetrics(object):
+    def __init__(self):
+        self.execution_time = defaultdict(lambda: 0.)
+        self.execution_count = defaultdict(lambda: 0)
+
+    def reset(self):
+        self.execution_time = defaultdict(lambda: 0.)
+        self.execution_count = defaultdict(lambda: 0)
+
+    @property
+    def data(self):
+        return {'execution_time': dict(self.execution_time), 'execution_count': dict(self.execution_count)}
+
+
+call_metrics = CallMetrics()
+
+
+def collect_metrics(func: Callable):
+    """Wraps the function to store total call time and number of calls in call_metrics.
+
+    :param func: Function to be wrapped
+    :return: Wrapped function that stores execution information to call_metrics.
+    """
+    @wraps(func)
+    def store_metrics(*args, **kwargs):
+        start_time = time()
+        result = func(*args, **kwargs)
+        end_time = time()
+        call_metrics.execution_count[func.__name__] += 1
+        call_metrics.execution_time[func.__name__] += end_time - start_time
+        return result
+
+    return store_metrics

--- a/tests/qed_optimization_problem.py
+++ b/tests/qed_optimization_problem.py
@@ -8,9 +8,11 @@ from rlmolecule.alphazero.alphazero_problem import AlphaZeroProblem
 from rlmolecule.alphazero.alphazero_vertex import AlphaZeroVertex
 from rlmolecule.molecule.molecule_problem import MoleculeProblem, MoleculeTFAlphaZeroProblem
 from rlmolecule.molecule.molecule_state import MoleculeState
+from rlmolecule.tree_search.metrics import collect_metrics
 
 
 class QEDOptimizationProblem(MoleculeProblem, AlphaZeroProblem, ABC):
+    @collect_metrics
     @functools.lru_cache(maxsize=None)
     def get_reward(self, state: MoleculeState) -> (float, {}):
         if state.forced_terminal:

--- a/tests/tree_search/test_metrics.py
+++ b/tests/tree_search/test_metrics.py
@@ -1,0 +1,68 @@
+import time
+from typing import Sequence
+
+from rlmolecule.mcts.mcts import MCTS
+from rlmolecule.mcts.mcts_problem import MCTSProblem
+from rlmolecule.tree_search.graph_search_state import GraphSearchState
+from rlmolecule.tree_search.metrics import call_metrics, collect_metrics
+from rlmolecule.tree_search.reward import RawRewardFactory
+
+
+class DummyState(GraphSearchState):
+    def __init__(self, position, is_terminal):
+        super(DummyState, self).__init__()
+        self.is_terminal = is_terminal
+        self.position = position
+
+    def equals(self, other: 'CyclicState') -> bool:
+        return (self.position == other.position) & (self.is_terminal == other.is_terminal)
+
+    def __repr__(self):
+        return f"{self.__class__}(position={self.position}, is_terminal={self.is_terminal})"
+
+    @collect_metrics
+    def get_next_actions(self) -> Sequence['GraphSearchState']:
+
+        time.sleep(0.1)
+
+        if self.is_terminal:
+            return []
+
+        else:
+            return [
+                DummyState(self.position, is_terminal=True),
+                DummyState((self.position + 1), is_terminal=False)
+            ]
+
+    def hash(self) -> int:
+        return hash((self.position, self.is_terminal))
+
+
+class DummyProblem(MCTSProblem):
+    def __init__(self, **kwargs):
+        super(DummyProblem, self).__init__(**kwargs)
+        self.call_count = 0
+
+    def get_initial_state(self) -> GraphSearchState:
+        return DummyState(0, is_terminal=False)
+
+    @collect_metrics
+    def get_reward(self, state: GraphSearchState) -> (float, {}):
+        self.call_count += 1
+        return 1, {}
+
+
+def test_metrics():
+    call_metrics.reset()
+    start = DummyState(0, is_terminal=False)
+    start.get_next_actions()
+    assert call_metrics.execution_count['get_next_actions'] == 1
+    assert call_metrics.execution_time['get_next_actions'] > 0.1
+    start.get_next_actions()
+    assert call_metrics.execution_count['get_next_actions'] == 2
+    assert call_metrics.execution_time['get_next_actions'] > 0.2
+
+    problem = DummyProblem(reward_class=RawRewardFactory())
+    game = MCTS(problem)
+    game.run(num_mcts_samples=5)
+    assert call_metrics.execution_count['get_reward'] == problem.call_count


### PR DESCRIPTION
Fixes #27

Provides a `@collect_metrics` decorator that can be used to collect total walltime and total number of calls for different functions. Stores the data to a `call_metrics` global object that gets reset before each game.

Not annotated in the documentation anywhere, but after each game this information also gets dumped to the GameStore table as JSON in the `execution_statistics` field.