### PR TITLE
TfServing for stable radical optimization

### DIFF
--- a/examples/stable_radical_optimization/config/tfserving_batch.config
+++ b/examples/stable_radical_optimization/config/tfserving_batch.config
@@ -1,0 +1,5 @@
+max_batch_size { value: 256 }
+batch_timeout_micros { value: 1000 }
+max_enqueued_batches { value: 1000000 }
+num_batch_threads { value: 16 }
+pad_variable_length_inputs: true

--- a/examples/stable_radical_optimization/stable_radical_opt.py
+++ b/examples/stable_radical_optimization/stable_radical_opt.py
@@ -311,6 +311,11 @@ def setup_argparser():
                         type=pathlib.Path,
                         required=True,
                         help='BDE model for computing the Bond Dissociation Energy')
+    parser.add_argument('--tfserving_hostname',
+                        '-H',
+                        action="store",
+                        default="localhost",
+                        help='For rollout workers, this specifies where to access TFServing (if it is available)')
 
     return parser
 

--- a/examples/stable_radical_optimization/submit_debug_tfserving.sh
+++ b/examples/stable_radical_optimization/submit_debug_tfserving.sh
@@ -59,9 +59,9 @@ hostname > $TFSERVING_HOSTNAME_PATH
 source /nopt/nrel/apps/anaconda/5.3/etc/profile.d/conda.sh
 conda activate /projects/rlmolecule/pstjohn/envs/tf2_gpu
 module load singularity-container
-SINGULARITYENV_MODEL_NAME=policy \
+SINGULARITYENV_MODEL_NAME=reward \
       singularity exec --nv \
-      -B "$tfserving_redox_model":/models/policy \
+      -B "$tfserving_redox_model":/models/reward \
       -B "$batch_config":/models/tfserving_batch.config \
       "$tfserving_img" \
       tf_serving_entrypoint.sh \

--- a/examples/stable_radical_optimization/submit_debug_tfserving.sh
+++ b/examples/stable_radical_optimization/submit_debug_tfserving.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+#SBATCH --partition=debug
+#SBATCH --account=rlmolecule
+#SBATCH --time=0:10:00
+#SBATCH --job-name=test_stable_rad_opt
+#SBATCH --nodes=1
+#SBATCH --gres=gpu:2
+#SBATCH --ntasks=9
+#SBATCH --cpus-per-task=4
+
+export WORKING_DIR=/scratch/${USER}/rlmolecule/stable_radical_optimization
+mkdir -p $WORKING_DIR
+
+export START_POLICY_SCRIPT="$SLURM_SUBMIT_DIR/$JOB/.policy.sh"
+export START_ROLLOUT_SCRIPT="$SLURM_SUBMIT_DIR/$JOB/.rollout.sh"
+export START_TFSERVING_SCRIPT="$SLURM_SUBMIT_DIR/$JOB/.tfserving.sh"
+
+# The following path needs to point to a shared directory, 
+# which will be accessible from both tfserving node and the rollout workers 
+export TFSERVING_HOSTNAME_PATH="$WORKING_DIR/tfserving_hostname.$SLURM_JOB_ID"
+
+# make sure the base folder of the repo is on the python path
+export PYTHONPATH="$(readlink -e ../../):$PYTHONPATH"
+
+model_dir="/projects/rlmolecule/pstjohn/models/"; 
+stability_model="$model_dir/20210214_radical_stability_new_data/"
+redox_model="$model_dir/20210214_redox_new_data/"
+bde_model="$model_dir/20210216_bde_new_nfp/"
+
+cat << EOF > "$START_POLICY_SCRIPT"
+#!/bin/bash
+source /nopt/nrel/apps/anaconda/5.3/etc/profile.d/conda.sh; 
+conda activate /projects/rlmolecule/pstjohn/envs/tf2_gpu
+python -u stable_radical_opt.py --train-policy \
+    --stability-model="$stability_model" \
+    --redox-model="$redox_model" \
+    --bde-model="$bde_model" 
+EOF
+
+cat << EOF > "$START_ROLLOUT_SCRIPT"
+#!/bin/bash
+source /nopt/nrel/apps/anaconda/5.3/etc/profile.d/conda.sh; 
+conda activate /projects/rlmolecule/pstjohn/envs/tf2_cpu
+tfserving_hostname=$(cat $TFSERVING_HOSTNAME_PATH)
+python -u stable_radical_opt.py --rollout \
+    --stability-model="$stability_model" \
+    --redox-model="$redox_model" \
+    --bde-model="$bde_model" \
+    --tfserving_hostname=$tfserving_hostname
+EOF
+
+tfserving_redox_model="$model_dir/20210216_redox_tfserving/"
+batch_config="./config/tfserving_batch.config"
+tfserving_img="/projects/rlmolecule/pstjohn/containers/tensorflow-serving-gpu.simg"
+cat << EOF > "$START_TFSERVING_SCRIPT"
+#!/bin/bash
+# This saves hostname to a file, which can be read from rollout workers 
+hostname > $TFSERVING_HOSTNAME_PATH
+source /nopt/nrel/apps/anaconda/5.3/etc/profile.d/conda.sh
+conda activate /projects/rlmolecule/pstjohn/envs/tf2_gpu
+module load singularity-container
+SINGULARITYENV_MODEL_NAME=policy \
+      singularity exec --nv \
+      -B "$tfserving_redox_model":/models/policy \
+      -B "$batch_config":/models/tfserving_batch.config \
+      "$tfserving_img" \
+      tf_serving_entrypoint.sh \
+      --enable_batching \
+      --batching_parameters_file=/models/tfserving_batch.config
+EOF
+
+chmod +x "$START_POLICY_SCRIPT" "$START_ROLLOUT_SCRIPT" "$START_TFSERVING_SCRIPT"
+
+# there are 36 cores on eagle nodes.
+
+# run tfserving
+srun --gres=gpu:1 --ntasks=1 --cpus-per-task=4 \
+     --output=$WORKING_DIR/tfserving.%j.out \
+     "$START_TFSERVING_SCRIPT" &
+
+# run one policy training job
+srun --gres=gpu:1 --ntasks=1 --cpus-per-task=4 \
+    --output=$WORKING_DIR/gpu.%j.out \
+    "$START_POLICY_SCRIPT" &
+
+# and run 7 cpu rollout jobs
+srun --gres=gpu:0 --ntasks=7 --cpus-per-task=4 \
+    --output=$WORKING_DIR/mcts.%j.out \
+    "$START_ROLLOUT_SCRIPT"
+

--- a/examples/tfserving_redox/predict_example.ipynb
+++ b/examples/tfserving_redox/predict_example.ipynb
@@ -1,0 +1,236 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Notebook for testing TFServing predictions (using wrapper class)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "sys.path.append(\"../../rlmolecule/tfserving\")\n",
+    "from tfserving_client import TFServingClient"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0            NaN\n",
+       "1            NaN\n",
+       "2            NaN\n",
+       "3       0.781466\n",
+       "4       0.313277\n",
+       "          ...   \n",
+       "1275         NaN\n",
+       "1276         NaN\n",
+       "1277    1.416731\n",
+       "1278    1.454662\n",
+       "1279    1.467125\n",
+       "Name: ionization energy, Length: 1280, dtype: float64"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'atom': array([2, 3, 4, 5, 5, 6, 7, 8, 8]),\n",
+       " 'bond': array([2, 2, 3, 3, 4, 3, 4, 3, 3, 5, 6, 3, 3, 3, 3, 3]),\n",
+       " 'connectivity': array([[0, 1],\n",
+       "        [1, 0],\n",
+       "        [1, 2],\n",
+       "        [2, 1],\n",
+       "        [2, 3],\n",
+       "        [2, 6],\n",
+       "        [3, 2],\n",
+       "        [3, 4],\n",
+       "        [4, 3],\n",
+       "        [4, 5],\n",
+       "        [5, 4],\n",
+       "        [6, 2],\n",
+       "        [6, 7],\n",
+       "        [6, 8],\n",
+       "        [7, 6],\n",
+       "        [8, 6]])}"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Prepare dataset for testing\n",
+    "\n",
+    "import pandas as pd\n",
+    "from rdkit import Chem\n",
+    "import tensorflow as tf\n",
+    "\n",
+    "import sys\n",
+    "sys.path.append('../../')\n",
+    "# Old import: from alphazero.preprocessor import preprocessor\n",
+    "from rlmolecule.molecule.policy.preprocessor import MolPreprocessor, load_preprocessor\n",
+    "\n",
+    "preprocessor = load_preprocessor()\n",
+    "\n",
+    "redox_df = pd.read_csv('/projects/rlmolecule/pstjohn/spin_gnn/redox_data.csv.gz').head(1280)\n",
+    "display(redox_df[\"ionization energy\"])\n",
+    "\n",
+    "test_dataset = tf.data.Dataset.from_generator(\n",
+    "    lambda: (preprocessor.construct_feature_matrices(Chem.MolFromSmiles(smiles), train=False) \n",
+    "             for smiles in redox_df.smiles),\n",
+    "output_types=preprocessor.output_types,\n",
+    "output_shapes=preprocessor.output_shapes)\\\n",
+    ".padded_batch(batch_size=128, padded_shapes=preprocessor.padded_shapes(),\n",
+    "padding_values=preprocessor.padding_values)\n",
+    "\n",
+    "inputs = list(preprocessor.construct_feature_matrices(Chem.MolFromSmiles(smiles), train=False) \n",
+    "              for smiles in redox_df.smiles)\n",
+    "inputs[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Help on class TFServingClient in module tfserving_client:\n",
+      "\n",
+      "class TFServingClient(builtins.object)\n",
+      " |  TFServingClient(endpoint, model_name, default_port=8500, signature_name='serving_default')\n",
+      " |  \n",
+      " |  This is a class for interacting with TFServing. \n",
+      " |  \n",
+      " |  This class allows establishing a chennel with a TFServing endpoint\n",
+      " |  and using it for efficient predictions. \n",
+      " |  \n",
+      " |  Args:\n",
+      " |      endpoint (str): TFServing's endpoint; should be in the form: '<hostname>:<port>';\n",
+      " |                      if port isn't specified, default port will be used.\n",
+      " |      model_name (str): Specific model being queried.\n",
+      " |      default_port (int): gRPC endpoint runs on port 8500 by default.\n",
+      " |      signature_name (str): optional.\n",
+      " |  \n",
+      " |  Methods defined here:\n",
+      " |  \n",
+      " |  __init__(self, endpoint, model_name, default_port=8500, signature_name='serving_default')\n",
+      " |      Initialize self.  See help(type(self)) for accurate signature.\n",
+      " |  \n",
+      " |  predict(self, query_input, tensorize=True, timeout_s=10.0, layer_name='dense')\n",
+      " |      Query tfserving endpoint with specific input.\n",
+      " |      \n",
+      " |      Args:\n",
+      " |           query_input (str): input that will be sent to tfserving. \n",
+      " |                              Assumes that input includes: 'atom', 'bond', 'connectivity'.\n",
+      " |           tensorize (bool): flag for required tensorization/reshaping of components of input.\n",
+      " |           timeout_s (int): request timeout in seconds.\n",
+      " |           layer_name (str): name of the layer for which values will be returned.\n",
+      " |  \n",
+      " |  ----------------------------------------------------------------------\n",
+      " |  Data descriptors defined here:\n",
+      " |  \n",
+      " |  __dict__\n",
+      " |      dictionary for instance variables (if defined)\n",
+      " |  \n",
+      " |  __weakref__\n",
+      " |      list of weak references to the object (if defined)\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "help(TFServingClient)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Establish a channel for using TFServing\n",
+    "\n",
+    "tfc = TFServingClient(\"r104u33\", \"reward\") # arguments: hostname for TFServing and name of model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "dtype: DT_FLOAT\n",
+      "tensor_shape {\n",
+      "  dim {\n",
+      "    size: 1\n",
+      "  }\n",
+      "  dim {\n",
+      "    size: 2\n",
+      "  }\n",
+      "}\n",
+      "float_val: 1.1218291521072388\n",
+      "float_val: -0.05435870960354805\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Example of getting a single prediction from TFServing\n",
+    "\n",
+    "result = tfc.predict(inputs[0])\n",
+    "print(result)\n",
+    "\n",
+    "# Expected predictions:  \n",
+    "# float_val: 1.1218291521072388\n",
+    "# float_val: -0.05435873568058014"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/rlmolecule/tfserving/tfserving_client.py
+++ b/rlmolecule/tfserving/tfserving_client.py
@@ -1,0 +1,62 @@
+import grpc
+import tensorflow as tf
+from tensorflow_serving.apis import predict_pb2
+from tensorflow_serving.apis import prediction_service_pb2_grpc
+import numpy as np
+
+class TFServingClient(object):
+    """This is a class for interacting with TFServing. 
+
+    This class allows establishing a chennel with a TFServing endpoint
+    and using it for efficient predictions. 
+
+    Args:
+        endpoint (str): TFServing's endpoint; should be in the form: '<hostname>:<port>';
+                        if port isn't specified, default port will be used.
+        model_name (str): Specific model being queried.
+        default_port (int): gRPC endpoint runs on port 8500 by default.
+        signature_name (str): optional.
+        
+    """
+    def __init__(self, endpoint, model_name, default_port=8500, signature_name='serving_default'):
+        self.model_name = model_name
+        
+        # Handle the case where port isn't specified
+        if ~((":" in endpoint) and (endpoint.split(":")[-1].isnumeric()))
+            endpoint = "%s:%d" % (endpoint, default_port)
+ 
+        self.endpoint = endpoint
+        self.channel = grpc.insecure_channel(self.endpoint)    
+        self.stub = prediction_service_pb2_grpc.PredictionServiceStub(self.channel)
+        self.grpc_request = predict_pb2.PredictRequest()
+        
+        # The following needs to match <name> from "SINGULARITYENV_MODEL_NAME=<name>..."
+        # used when singularity container running tfserving is launched  
+        grpc_request.model_spec.name = self.model_name
+       
+        grpc_request.model_spec.signature_name = signature_name
+
+    def predict(self, query_input, tensorize=True, timeout_s=10.0, layer_name="dense"):
+        """ Query tfserving endpoint with specific input.
+
+        Args:
+             query_input (str): input that will be sent to tfserving. 
+                                Assumes that input includes: 'atom', 'bond', 'connectivity'.
+             tensorize (bool): flag for required tensorization/reshaping of components of input.
+             timeout_s (int): request timeout in seconds.
+             layer_name (str): name of the layer for which values will be returned.
+        """ 
+
+        if tensorize:
+            query_input['atom'] = tf.make_tensor_proto(query_input['atom'], 
+                                                       shape=[1, len(query_input['atom'])])
+            query_input['bond'] = tf.make_tensor_proto(query_input['bond'], 
+                                                       shape=[1, len(query_input['bond'])])
+            query_input['connectivity'] = tf.make_tensor_proto(query_input['connectivity'], 
+                                                               shape=[1] + list(np.array(query_input['connectivity']).shape))
+        for c in ['atom', 'bond', 'connectivity']:
+            self.grpc_request.inputs[c].CopyFrom(query_input[c]) 
+
+        result = self.stub.Predict.future(self.grpc_request, timeout_s) 
+        return result.outputs[layer_name]
+


### PR DESCRIPTION
Some notes:
- `examples/tfserving_redox/predict_example.ipynb` -- shows how to use a running instance of TFServing; it is taking advantage of the class implemented in `rlmolecule/tfserving/tfserving_client.py`, which handles setup & prediction nuances. Batching is enabled, and the `predict()` method uses non-blocking gRPC requests (proved to be the fastest way). 
- `examples/stable_radical_optimization/submit_debug_tfserving.sh` -- job script for Eagle, which launches TFServing in addition to the policy and rollout tasks.
- all pieces have been tested; next: rollout worker code needs to be updated to use TFServing (following the example in the notebook).
