### PR TITLE
Code to generate canonical tautomers

### DIFF
--- a/tests/mcts/test_mcts_qed.py
+++ b/tests/mcts/test_mcts_qed.py
@@ -18,7 +18,9 @@ def problem(request, engine):
                               min_atoms=1,
                               tryEmbedding=False,
                               sa_score_threshold=None,
-                              stereoisomers=False)
+                              stereoisomers=False,
+                              canonicalize_tautomers=True
+                              )
 
     if name == 'random':
         return QEDWithRandomPolicy(reward_class=LinearBoundedRewardFactory(), builder=builder, engine=engine)

--- a/tests/molecule/test_builder.py
+++ b/tests/molecule/test_builder.py
@@ -60,3 +60,18 @@ def test_cache():
         next_mols = to_smiles(MoleculeBuilder(cache_dir=tempdir, num_shards=2)(MolFromSmiles('C=CC')))
 
     assert next_mols
+
+
+def test_tautomers():
+    from rlmolecule.molecule.builder.builder import MoleculeBuilder, TautomerCanonicalizer, TautomerEnumerator
+
+    start = rdkit.Chem.MolFromSmiles('CC1=C(O)CCCC1')
+    mols = to_smiles(TautomerEnumerator()([start]))
+    assert len(mols) == 3
+    assert mols[0] != mols[1]
+
+    mols_canonical = to_smiles(TautomerCanonicalizer()([rdkit.Chem.MolFromSmiles(smiles) for smiles in mols]))
+    assert len(mols_canonical) == 1
+
+    builder_tautomers = MoleculeBuilder(canonicalize_tautomers=True)
+    products = to_smiles(builder_tautomers(start))


### PR DESCRIPTION
If enabled, treats each node in the graph as a collection of tautomers, with the molecule representing the 'canonical' tautomer as defined by rdkit. Next actions include modifications to tautomers of the current state